### PR TITLE
Add dco.txt

### DIFF
--- a/dco.txt
+++ b/dco.txt
@@ -1,0 +1,37 @@
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+1 Letterman Drive
+Suite D4700
+San Francisco, CA, 94129
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.


### PR DESCRIPTION
Add the Developer Certificate of Origin file (`dco.txt`), as required by the Hibernate governance process.

The file content is identical to the one in [hibernate-orm](https://github.com/hibernate/hibernate-orm/blob/main/dco.txt).

The Commonhaus policy checker isn't happy until the file is in the precise repository being checked; the `.github` repository is ignored. Which kind of makes sense for `dco.txt`. See https://github.com/commonhaus/foundation/blob/9688098bb6c5bbb55f27505400816ec0c46b6743/templates/panda/PolicyPanda.java#L202-L211